### PR TITLE
Add mixin to EventFactory

### DIFF
--- a/src/Events/EventFactory.php
+++ b/src/Events/EventFactory.php
@@ -3,9 +3,11 @@
 namespace Telegram\Bot\Events;
 
 use Closure;
+use Illuminate\Events\Dispatcher;
 
 /**
  * Class EventFactory
+ * @mixin Dispatcher
  */
 class EventFactory
 {


### PR DESCRIPTION
WIth static analysis enabled on the project, and the latest changes to the laravel package `WebhookController` after discussion last night, we now call a method `hasListeners` on this event factory. This event factory uses magic `__call` to pass undefined methods to the underlining Illuminate Dispatcher class.

Without the mixin tag the static analysis does not know we are doing this and so thinks we are calling an undefined method. This fixes this issue.