### PR TITLE
Add Backward compatibility check to CI

### DIFF
--- a/.github/workflows/backward-compatibility-check.yml
+++ b/.github/workflows/backward-compatibility-check.yml
@@ -1,0 +1,15 @@
+on: [push]
+name: Backward compatibility check
+
+jobs:
+  bc-check:
+    name: Backward compatibility check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Roave BC Check
+        uses: docker://nyholm/roave-bc-check-ga


### PR DESCRIPTION
Note, this is pretty heavy option that will fail on every commit until we release 4.0.0. (it will compare latest tagged version [which is v3.1.0] and git HEAD). But it also generates a list of all BC changes what will be good for writing upgrade notes.


Output example (from another package): https://github.com/koot-labs/telegram-bot-dialogs/runs/7196236917?check_suite_focus=true
```
[BC] REMOVED: Property KootLabs\TelegramBotDialogs\Dialog#$update was removed
[BC] REMOVED: Property KootLabs\TelegramBotDialogs\Dialog#$current was removed
[BC] REMOVED: Method KootLabs\TelegramBotDialogs\Dialog#setNext() was removed
[BC] REMOVED: Method KootLabs\TelegramBotDialogs\Dialog#getNext() was removed
[BC] REMOVED: Method KootLabs\TelegramBotDialogs\Dialog#setUpdate() was removed
[BC] REMOVED: Method KootLabs\TelegramBotDialogs\Dialog#setBot() was removed
[BC] REMOVED: Method KootLabs\TelegramBotDialogs\Dialog#getChat() was removed
[BC] CHANGED: KootLabs\TelegramBotDialogs\Dialog#setBot() was marked "@internal"
[BC] CHANGED: The number of required arguments for KootLabs\TelegramBotDialogs\Dialog#start() increased from 0 to 1
[BC] CHANGED: The number of required arguments for KootLabs\TelegramBotDialogs\Dialog#proceed() increased from 0 to 1
[BC] CHANGED: Method jump() of class KootLabs\TelegramBotDialogs\Dialog visibility reduced from public to protected
[BC] CHANGED: Method remember() of class KootLabs\TelegramBotDialogs\Dialog visibility reduced from public to protected
12 backwards-incompatible changes detected
```


as the next step it will be nice to privatize some methods and properties:
 - from `public` and `protected` to `private when possible`
 - add `final` to all `public` and `protected` members and classes where it makes sense
