### PR TITLE
Add `Bot::getName()` method

### DIFF
--- a/src/Bot.php
+++ b/src/Bot.php
@@ -32,6 +32,7 @@ class Bot
     use HasConfig;
     use HasContainer;
 
+    protected string $name;
     protected Api $api;
     protected EventFactory $eventFactory;
     protected array $listeners;
@@ -46,6 +47,7 @@ class Bot
     public function __construct(array $config = [])
     {
         $this->config = $config;
+        $this->name = $config['bot'];
 
         $this->api = new Api($this->config('token'));
         $this->setHttpClientHandler($this->config('global.http.client', GuzzleHttpClient::class));
@@ -62,6 +64,16 @@ class Bot
         }
 
         AddonManager::loadAddons($this);
+    }
+
+    /**
+     * Get name of the bot (specified in a config).
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Objects/Updates/ChatMemberUpdated.php
+++ b/src/Objects/Updates/ChatMemberUpdated.php
@@ -11,7 +11,7 @@ use Telegram\Bot\Objects\User;
 /**
  * Class Message.
  *
- * @link https://core.telegram.org/bots/api#message
+ * @link https://core.telegram.org/bots/api#chatmemberupdated
  *
  * @property Chat           $chat                Chat the user belongs to
  * @property User           $from                Performer of the action, which resulted in the change


### PR DESCRIPTION
When build addons to use in multi-bot apps it's important to be able to distinct bots when you have a Bot instance only. My use-case: Dialogs addon where I don't have enough context about the bot and need to know something unique about it in order to store Dialog state to DB