### PR TITLE
Demo of fake ability

### DIFF
--- a/src/Bot.php
+++ b/src/Bot.php
@@ -26,7 +26,7 @@ use Telegram\Bot\Traits\HasContainer;
  *
  * @mixin Api
  */
-final class Bot
+class Bot
 {
     use ForwardsCalls;
     use Macroable {

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -130,7 +130,9 @@ final class BotManager
      */
     private function makeBot(string $name): Bot
     {
-        return (new Bot($this->getBotConfig($name)))->setContainer($this->getContainer());
+        //Using the FakeBot here as it has the extra functionality
+        //But if this was moved into Bot I suppose we could revert back to normal Bot
+        return (new FakeBot($this->getBotConfig($name)))->setContainer($this->getContainer());
     }
 
     /**

--- a/src/FakeBot.php
+++ b/src/FakeBot.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Telegram\Bot;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class FakeBot extends Bot
+{
+    public static bool $recording = false;
+
+    public array $calledMethods = [];
+
+    public function __call($method, $parameters)
+    {
+        if (self::$recording) {
+            $this->calledMethods[] = [$method, $parameters[0]];
+        } else {
+            parent::__call($method, $parameters);
+        }
+    }
+
+    public function assertApiMethodWasCalled(string $methodName, $times = 1)
+    {
+        $count = collect($this->calledMethods)->filter(fn ($value) => is_array($value) && in_array($methodName, $value))->count();
+
+        PHPUnit::assertSame(
+            $times,
+            $count,
+            "The expected method was called [{$count}] times instead of [{$times}]."
+        );
+    }
+
+    public function assertApiPayloadToMatch(string $methodName, iterable $array, string $message = ''): self
+    {
+        foreach ($this->calledMethods as $calledMethod) {
+            if (is_array($calledMethod) && $calledMethod[0] === $methodName) {
+                $payload = $calledMethod[1];
+                foreach ($array as $key => $value) {
+                    PHPUnit::assertArrayHasKey($key, $payload, $message);
+
+                    if ($message === '') {
+                        $message = sprintf(
+                            'Failed asserting that an array has a key %s with the value %s.',
+                            $key,
+                            $payload[$key],
+                        );
+                    }
+
+                    PHPUnit::assertEquals($value, $payload[$key], $message);
+                }
+            }
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
PROTOTYPE! Very simplistic

Idea behind this is to allow you to check what methods and payloads were sent to your Telegram bot.

I had to remove final on the Bot class to allow me to extend it. I hope to be able to add it back again soon.

Assert code inspired by some the new assert methods on the new Sleep facade in laravel
https://github.com/laravel/framework/blob/0da22a8d179f79b49d4e71f4822f759651f35012/src/Illuminate/Support/Sleep.php

You also need to pull in the small change in the Telegram Laravel repo that updates the Telegram Facade


Once you have pulled in these branches to your project, you can make a test  like so:

```php
it('tests telegram fake facility', function () {
    Telegram::fake();

    Telegram::bot()->sendMessage(['chat_id' => 123456, 'text' => 'hello', 'parse_mode' => 'HTML']);

    Telegram::bot()->assertApiMethodWasCalled('sendMessage', times: 1);
    Telegram::bot()->assertApiPayloadToMatch('sendMessage', ['text' => 'hello']);
});
```

What I attempted to do:

When Telegram::fake is called, set a flag on the bot class to enable any methods called on the bot object to be recorded.

The user then runs their code which calls methods on the bot object.
This can then be checked and assertions made on the data passed to the api method calls.

TODO

Everything! This is a terrible demo!
Allow fake responses/reply from methods called on the bot object?
Allow a closure to be used in the assert methods like so:

```php
it('tests telegram fake facility', function () {
    Telegram::fake();

    Telegram::bot()->sendMessage(['chat_id' => 123456, 'text' => 'hello', 'parse_mode' => 'HTML']);

    Telegram::bot()->assertApiPayloadToMatch('sendMessage', function($params){
        //Carry out custom checks on the $params passed to the sendMessage method
        
    });
});
```